### PR TITLE
Fix for appending command args

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -82,7 +82,7 @@ final class Command
     public function withArgs(array $args, bool $append = false): self
     {
         if ($append) {
-            $args = $this->args + $args;
+            $args = array_merge($this->args, $args);
         }
 
         return new self($this->cmd, $args, $this->env, $this->workDir);


### PR DESCRIPTION
When appending arrays, array_merge should be used (see https://3v4l.org/bL1I4)