### PR TITLE
Added possibility to set default timeout to ExegSymfony

### DIFF
--- a/src/Symfony/ExegSymfony.php
+++ b/src/Symfony/ExegSymfony.php
@@ -8,20 +8,36 @@ use Vcn\Exeg\Command;
 
 class ExegSymfony
 {
+    /**
+     * @var null|callable
+     */
     private $defaultCallback = null;
 
-    public function __construct(?callable $defaultCallback = null)
+    /**
+     * @var null|int
+     */
+    private $defaultTimeout = null;
+
+    public function __construct(?callable $defaultCallback = null, ?int $defaultTimeout = null)
     {
         if (!class_exists(Process::class)) {
             throw new RuntimeException(sprintf("Please install symfony/process to make use of %s", self::class));
         }
 
         $this->defaultCallback = $defaultCallback;
+        $this->defaultTimeout  = $defaultTimeout;
     }
 
     public function setDefaultCallback(?callable $callback): self
     {
         $this->defaultCallback = $callback;
+
+        return $this;
+    }
+
+    public function setDefaultTimeout(?int $defaultTimeout): self
+    {
+        $this->defaultTimeout = $defaultTimeout;
 
         return $this;
     }
@@ -44,6 +60,10 @@ class ExegSymfony
 
         if ($env !== null) {
             $process->setEnv($env);
+        }
+
+        if ($this->defaultTimeout !== null) {
+            $process->setTimeout($this->defaultTimeout);
         }
 
         return $process;

--- a/src/Symfony/ExegSymfony.php
+++ b/src/Symfony/ExegSymfony.php
@@ -19,9 +19,7 @@ class ExegSymfony
     private $defaultTimeout = null;
 
     /**
-     * ExegSymfony constructor.
-     *
-     * @param null|callable $defaultCallback
+     * @param null|callable $defaultCallback  Process callback. {@See Process::run()} for details.
      * @param null|int      $defaultTimeout   Timeout in seconds. Null to use Symfony's default, 0 to disable timeouts.
      */
     public function __construct(?callable $defaultCallback = null, ?int $defaultTimeout = null)
@@ -34,6 +32,11 @@ class ExegSymfony
         $this->defaultTimeout  = $defaultTimeout;
     }
 
+    /**
+     * @param null|callable $callback Process callback. {@See Process::run()} for details.
+     *
+     * @return ExegSymfony
+     */
     public function setDefaultCallback(?callable $callback): self
     {
         $this->defaultCallback = $callback;

--- a/src/Symfony/ExegSymfony.php
+++ b/src/Symfony/ExegSymfony.php
@@ -18,6 +18,12 @@ class ExegSymfony
      */
     private $defaultTimeout = null;
 
+    /**
+     * ExegSymfony constructor.
+     *
+     * @param null|callable $defaultCallback
+     * @param null|int      $defaultTimeout   Timeout in seconds. Null to use Symfony's default, 0 to disable timeouts.
+     */
     public function __construct(?callable $defaultCallback = null, ?int $defaultTimeout = null)
     {
         if (!class_exists(Process::class)) {
@@ -35,6 +41,11 @@ class ExegSymfony
         return $this;
     }
 
+    /**
+     * @param null|int $defaultTimeout Timeout in seconds. Null to use Symfony's default, 0 to disable timeouts.
+     *
+     * @return ExegSymfony
+     */
     public function setDefaultTimeout(?int $defaultTimeout): self
     {
         $this->defaultTimeout = $defaultTimeout;


### PR DESCRIPTION
In some cases, this is more convenient than setting the timeout on each Process created by ExegSymfony.